### PR TITLE
Add conda export to environment block

### DIFF
--- a/build/pyraf.def
+++ b/build/pyraf.def
@@ -59,6 +59,7 @@ From: ubuntu:20.04
 
 %environment
     # Persist environment variable setup across sessions
+    export PATH=/opt/conda/bin:$PATH
 
 %runscript
     # When the container runs, execute necessary shell environment setup


### PR DESCRIPTION
This PR fixes the conda source by adding the export to environment block. Before this change `conda` would not initialize.